### PR TITLE
Implement admin_level counts, Add first test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cosmogony"
 version = "0.1.0"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>"]
+build = "build.rs"
 
 [dependencies]
 log = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+// this file is used to be able to use OUT_DIR env variable
+
+fn main() {}

--- a/src/bin/cosmogony.rs
+++ b/src/bin/cosmogony.rs
@@ -1,0 +1,21 @@
+extern crate cosmogony;
+extern crate mimir;
+extern crate structopt;
+#[macro_use]
+extern crate structopt_derive;
+
+use cosmogony::build_cosmogony;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+struct Args {
+    /// OSM PBF file.
+    #[structopt(short = "i", long = "input")]
+    input: String,
+}
+
+fn main() {
+    mimir::logger_init();
+    let args = Args::from_args();
+    build_cosmogony(args.input);
+}

--- a/src/cosmogony.rs
+++ b/src/cosmogony.rs
@@ -14,7 +14,7 @@ pub struct CosmogonyMetadata {
     // errors:
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct CosmogonyStats {
     pub level_counts: BTreeMap<u32, u64>,
 }

--- a/src/cosmogony.rs
+++ b/src/cosmogony.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeMap;
+use zone::Zone;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Cosmogony {
+    pub zones: Vec<Zone>,
+    pub meta: CosmogonyMetadata,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CosmogonyMetadata {
+    pub osm_filename: String,
+    pub stats: CosmogonyStats,
+    // errors:
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CosmogonyStats {
+    pub level_counts: BTreeMap<u32, u64>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,12 @@ mod zone;
 mod admin_type;
 mod cosmogony;
 
-use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::Path;
 use mimirsbrunn::osm_reader::OsmPbfReader;
 use itertools::Itertools;
 use mimirsbrunn::boundaries::{build_boundary, make_centroid};
 use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
-
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn is_admin(obj: &osmpbfreader::OsmObj) -> bool {
@@ -41,9 +39,7 @@ pub fn get_zones_and_stats(pbf: &mut OsmPbfReader) -> (Vec<zone::Zone>, Cosmogon
     info!("reading pbf done.");
 
     let mut zones = vec![];
-    let mut stats = CosmogonyStats {
-        level_counts: BTreeMap::new()
-    };
+    let mut stats = CosmogonyStats::default();
 
     for obj in objects.values() {
         if !is_admin(obj) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,9 @@ pub fn get_zones_and_stats(pbf: &mut OsmPbfReader) -> (Vec<zone::Zone>, Cosmogon
     info!("reading pbf done.");
 
     let mut zones = vec![];
-    let mut counts = BTreeMap::new();
+    let mut stats = CosmogonyStats {
+        level_counts: BTreeMap::new()
+    };
 
     for obj in objects.values() {
         if !is_admin(obj) {
@@ -101,16 +103,13 @@ pub fn get_zones_and_stats(pbf: &mut OsmPbfReader) -> (Vec<zone::Zone>, Cosmogon
             }
 
             zone.admin_level.map(|level| {
-                let count = counts.entry(level).or_insert(0);
+                let count = stats.level_counts.entry(level).or_insert(0);
                 *count += 1;
             });
             zones.push(zone);
         }
     }
 
-    let stats = CosmogonyStats {
-        level_counts: counts,
-    };
     return (zones, stats);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,6 @@ pub fn is_admin(obj: &osmpbfreader::OsmObj) -> bool {
                 .map_or(false, |v| v == "administrative")
             &&
             rel.tags.get("admin_level").is_some()
-            // &&
-            // rel.tags.get("type").map_or(false, |v| v == "boundary")
         }
         _ => false,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,51 +7,43 @@ extern crate mimirsbrunn;
 extern crate osmpbfreader;
 #[macro_use]
 extern crate serde_derive;
-extern crate structopt;
-#[macro_use]
-extern crate structopt_derive;
-
-use structopt::StructOpt;
-use mimirsbrunn::osm_reader::parse_osm_pbf;
-use mimirsbrunn::osm_reader::OsmPbfReader;
-use itertools::Itertools;
-use mimirsbrunn::boundaries::{build_boundary, make_centroid};
 
 mod zone;
 mod admin_type;
+mod cosmogony;
 
-#[derive(StructOpt, Debug)]
-struct Args {
-    /// OSM PBF file.
-    #[structopt(short = "i", long = "input")]
-    input: String,
-}
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::Path;
+use mimirsbrunn::osm_reader::OsmPbfReader;
+use itertools::Itertools;
+use mimirsbrunn::boundaries::{build_boundary, make_centroid};
+use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
 
-fn main() {
-    mimir::logger_init();
-    let args = Args::from_args();
 
-    let mut parsed_pbf = parse_osm_pbf(&args.input);
-    let zones = get_zones(&mut parsed_pbf);
-}
-
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn is_admin(obj: &osmpbfreader::OsmObj) -> bool {
     match *obj {
         osmpbfreader::OsmObj::Relation(ref rel) => {
             rel.tags
                 .get("boundary")
                 .map_or(false, |v| v == "administrative")
-            && 
+            &&
             rel.tags.get("admin_level").is_some()
+            // &&
+            // rel.tags.get("type").map_or(false, |v| v == "boundary")
         }
         _ => false,
     }
 }
 
-pub fn get_zones(pbf: &mut OsmPbfReader) {
+pub fn get_zones_and_stats(pbf: &mut OsmPbfReader) -> (Vec<zone::Zone>, CosmogonyStats) {
     info!("reading pbf...");
     let objects = pbf.get_objs_and_deps(|o| is_admin(o)).unwrap();
     info!("reading pbf done.");
+
+    let mut zones = vec![];
+    let mut counts = BTreeMap::new();
 
     for obj in objects.values() {
         if !is_admin(obj) {
@@ -105,7 +97,38 @@ pub fn get_zones(pbf: &mut OsmPbfReader) {
                 tags: vec![],
             };
 
-            println!("{:?}", zone);
+            // Ignore zone without boundary polygon
+            if zone.boundary.is_none() {
+                continue;
+            }
+
+            zone.admin_level.map(|level| {
+                let count = counts.entry(level).or_insert(0);
+                *count += 1;
+            });
+            zones.push(zone);
         }
     }
+
+    let stats = CosmogonyStats {
+        level_counts: counts,
+    };
+    return (zones, stats);
+}
+
+pub fn build_cosmogony(pbf_path: String) -> Cosmogony {
+    let path = Path::new(&pbf_path);
+    let file = File::open(&path).unwrap();
+
+    let mut parsed_pbf = osmpbfreader::OsmPbfReader::new(file);
+
+    let (zones, stats) = get_zones_and_stats(&mut parsed_pbf);
+    let cosmogony = Cosmogony {
+        zones: zones,
+        meta: CosmogonyMetadata {
+            osm_filename: path.file_name().unwrap().to_str().unwrap().to_string(),
+            stats: stats,
+        },
+    };
+    cosmogony
 }

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -20,7 +20,7 @@ pub struct Zone {
 }
 
 impl Zone {
-    fn is_admin(&self) -> bool {
+    pub fn is_admin(&self) -> bool {
         match self.admin_type {
             None => false,
             Some(AdminType::NonAdministrative) => false,

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -3,7 +3,6 @@ extern crate cosmogony;
 use std::collections::BTreeMap;
 
 #[test]
-#[cfg_attr(rustfmt, rustfmt_skip)]
 fn read_lux_admin_levels() {
     // Ensure that all well-defined (with closed boundaries)
     // administrative zones are loaded from the sample .osm.pbf file,
@@ -22,19 +21,21 @@ fn read_lux_admin_levels() {
         assert_eq!(
             *counts.get(&key).unwrap_or(&0),
             value,
-            "Expected {} admins at level {}", value, key
+            "Expected {} admins at level {}",
+            value,
+            key
         )
     }
 
-    assert_count(&level_counts, 2,  1);  // 1 x admin_level==2
-    assert_count(&level_counts, 3,  0);  // 0 x admin_level==3
-    assert_count(&level_counts, 4,  0);  // etc.
-    assert_count(&level_counts, 5,  0);  
-    assert_count(&level_counts, 6,  13);  // 12 cantons + 1 territory (DE-LU)
-    assert_count(&level_counts, 7,  0);
-    assert_count(&level_counts, 8,  105); // 104 + 1 outside LU
-    assert_count(&level_counts, 9,  79);
-    assert_count(&level_counts, 10, 3);   // 2 + 1 outside LU
+    assert_count(&level_counts, 2, 1); // 1 x admin_level==2
+    assert_count(&level_counts, 3, 0); // 0 x admin_level==3
+    assert_count(&level_counts, 4, 0); // etc.
+    assert_count(&level_counts, 5, 0);
+    assert_count(&level_counts, 6, 13); // 12 cantons + 1 territory (DE-LU)
+    assert_count(&level_counts, 7, 0);
+    assert_count(&level_counts, 8, 105); // 104 + 1 outside LU
+    assert_count(&level_counts, 9, 79);
+    assert_count(&level_counts, 10, 3); // 2 + 1 outside LU
 
     assert_eq!(cosmogony.zones.len(), 201);
 }

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -1,0 +1,36 @@
+extern crate cosmogony;
+
+use std::collections::BTreeMap;
+
+#[test]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn read_lux_admin_levels() {
+    let test_file = concat!(
+        env!("OUT_DIR"),
+        "/../../../../../tests/data/luxembourg_filtered.osm.pbf"
+    );
+    let cosmogony = cosmogony::build_cosmogony(test_file.into());
+    assert_eq!(cosmogony.meta.osm_filename, "luxembourg_filtered.osm.pbf");
+
+    let level_counts = cosmogony.meta.stats.level_counts;
+
+    fn assert_count(counts: &BTreeMap<u32, u64>, key: u32, value: u64) {
+        assert_eq!(
+            *counts.get(&key).unwrap_or(&0),
+            value,
+            "Expected {} admins at level {}", value, key
+        )
+    }
+
+    assert_count(&level_counts, 2,  1);  // 1 x admin_level==2
+    assert_count(&level_counts, 3,  0);  // 0 x admin_level==3
+    assert_count(&level_counts, 4,  0);  // etc.
+    assert_count(&level_counts, 5,  0);  
+    assert_count(&level_counts, 6,  13);  // 12 cantons + 1 territory (DE-LU)
+    assert_count(&level_counts, 7,  0);
+    assert_count(&level_counts, 8,  105); // 104 + 1 outside LU
+    assert_count(&level_counts, 9,  79);
+    assert_count(&level_counts, 10, 3);   // 2 + 1 outside LU
+
+    assert_eq!(cosmogony.zones.len(), 201);
+}

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -5,6 +5,10 @@ use std::collections::BTreeMap;
 #[test]
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn read_lux_admin_levels() {
+    // Ensure that all well-defined (with closed boundaries)
+    // administrative zones are loaded from the sample .osm.pbf file,
+    // with correct counts per admin_level.
+
     let test_file = concat!(
         env!("OUT_DIR"),
         "/../../../../../tests/data/luxembourg_filtered.osm.pbf"


### PR DESCRIPTION
Note that zones without boundary are currently ignored in the result.

A single test is implemented to check the number of zones per admin_level in a sample .osm.pbf.